### PR TITLE
remove engine declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,5 @@
   },
   "devDependencies": {
     "mocha": "0.12.x"
-  },
-  "engines": { "node": "0.6.x" }
+  }
 }


### PR DESCRIPTION
this repo obviously works with engines newer then what was specified. This just results in an extra noisy warning

```
npm WARN engine makeerror@1.0.10: wanted: {"node":"0.6.x"} (current: {"node":"1.6.2","npm":"2.7.3"})
```
